### PR TITLE
feat: add activity selector (type_uid 400101, Open) to the network_connection mapping

### DIFF
--- a/sigma/pipelines/ocsf/ocsf.py
+++ b/sigma/pipelines/ocsf/ocsf.py
@@ -54,7 +54,7 @@ ocsf_generic_logsource_category_mapping = {  # map generic Sigma log source cate
         "type_uid": 100799,
         "activity_name": "Load",
     },
-    "network_connection": {"class_uid": 4001},
+    "network_connection": {"type_uid": 400101},
     # "pipe_created": [17, 18],
     "process_access": {
         "type_uid": 100799,

--- a/tests/test_processing_pipelines_ocsf.py
+++ b/tests/test_processing_pipelines_ocsf.py
@@ -91,7 +91,7 @@ def test_ocsf_image_load(backend, image_load_sigma_rule):
 
 def test_ocsf_network_connect(backend, network_connection_sigma_rule):
     assert backend.convert(network_connection_sigma_rule) == [
-        'class_uid=4001 and unmapped.Initiated="true" and dst_endpoint.ip="1.2.3.4" '
+        'type_uid=400101 and unmapped.Initiated="true" and dst_endpoint.ip="1.2.3.4" '
         'and connection_info.protocol_name="tcp" and actor.process.file.name="test.exe" '
         'and actor.process.parent_process.file.name="parent.exe" '
         'and actor.process.cmd_line="test.exe foo bar" and unmapped.SourceIsIpv6="false"'


### PR DESCRIPTION
Follow-on to #18, which corrected and deepened the `network_connection` field mappings but deliberately left the OCSF activity selector as an open question: the 4001 block carried only `class_uid`, with no `activity_id`/`type_uid`, so converted network-connection rules selected the Network Activity class but no activity.

This sets it to `type_uid: 400101` — OCSF Network Activity `class_uid 4001` × `activity_id 1` ("Open", a new network connection was opened) — matching the pipeline's own convention of encoding the activity via `type_uid` (as `process_creation`, `file_event`, etc. already do; the `class_uid`-only entries like `firewall`/`dns` are the activity-ambiguous ones).

A Sigma `network_connection` rule corresponds to Sysmon Event ID 3 ("Network connection detected") — a connection being made — so "Open" is the defensible default. The alternative, if you'd rather treat these as traffic reports, is `activity_id 6` ("Traffic") → `type_uid 400106`. I went with Open per the connection-establishment semantics; happy to switch to Traffic if you prefer.

Updated `test_ocsf_network_connect` to assert `type_uid=400101`. `black --check .` and `pytest` are green locally (29 passed).